### PR TITLE
Feature: create before action

### DIFF
--- a/.github/workflows/fake-deploy.yml
+++ b/.github/workflows/fake-deploy.yml
@@ -9,21 +9,18 @@ on:
   workflow_dispatch:
 jobs:
   deploy:
+    name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - name: Start deploy
-        id: start
-        run: |
-          echo "::set-output name=time::$(date +%s)\n"
-
       - name: Checkout code
         uses: actions/checkout@v2
-
+      - name: Before action
+        id: before-action
+        uses: ./before-action
       - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      # Add or Replace any other Linters here
       - name: Deploy
         id: deploy
         run: |
@@ -39,4 +36,4 @@ jobs:
           INFLUX_ORG: ${{ secrets.INFLUX_ORG }}
           INFLUX_BUCKET: ${{ secrets.INFLUX_BUCKET }}
         run: |
-          bundle exec ruby deployment-frequency.rb --started_at ${{ steps.start.outputs.time }} --finished_at ${{ steps.deploy.outputs.finished_at }} --status ${{ steps.deploy.outcome }} --commit_sha $GITHUB_SHA --project_name $(basename $GITHUB_REPOSITORY) --branch_name $(echo $GITHUB_REF | sed s#refs/heads/## ) --repository_url ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}  --environment "prod" --hosting_environment "dalmatian" --deployment_id $GITHUB_RUN_ID
+          bundle exec ruby deployment-frequency.rb --started_at ${{ steps.before-action.outputs.start-time }} --finished_at ${{ steps.deploy.outputs.finished_at }} --status ${{ steps.deploy.outcome }} --commit_sha $GITHUB_SHA --project_name $(basename $GITHUB_REPOSITORY) --branch_name $(echo $GITHUB_REF | sed s#refs/heads/## ) --repository_url ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}  --environment "prod" --hosting_environment "dalmatian" --deployment_id $GITHUB_RUN_ID

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,8 +36,10 @@ GEM
       faraday (> 0.8, < 2.0)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   dotenv

--- a/before-action-dockerfile
+++ b/before-action-dockerfile
@@ -1,0 +1,7 @@
+FROM alpine
+
+RUN apk add bash
+
+COPY scripts /scripts
+
+ENTRYPOINT ["/scripts/before-action.sh"]

--- a/before-action/action.yml
+++ b/before-action/action.yml
@@ -1,0 +1,9 @@
+# action.yml
+name: 'Before action '
+description: 'Sets up variables to record metrics'
+outputs:
+  start-time:
+    description: 'The time the workflow run started'
+runs:
+  using: 'docker'
+  image: '../before-action-dockerfile'

--- a/scripts/before-action.sh
+++ b/scripts/before-action.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -l
+
+time=$(date)
+echo "::set-output name=start-time::$time"


### PR DESCRIPTION
The goals is to have a reusable action that is included before the deployment steps that sets things up. 

All it currently does is record the time the step started so it can be used later.

There is a big gotya here: to use the `output` of the step you have to set the step `id` for later use, this is a bit frustrating, but may be my lack of experience with Github acitons.
