### PR TITLE
Feature: after action

### DIFF
--- a/.github/workflows/fake-deploy.yml
+++ b/.github/workflows/fake-deploy.yml
@@ -28,7 +28,9 @@ jobs:
           sleep 5
           echo "fake deploy finished"
           echo "::set-output name=finished_at::$(date +%s)\n"
-
+      - name: After action
+        id: after-action
+        uses: ./after-action
 
       - name: Send data to influxdb
         env:
@@ -36,4 +38,4 @@ jobs:
           INFLUX_ORG: ${{ secrets.INFLUX_ORG }}
           INFLUX_BUCKET: ${{ secrets.INFLUX_BUCKET }}
         run: |
-          bundle exec ruby deployment-frequency.rb --started_at ${{ steps.before-action.outputs.start-time }} --finished_at ${{ steps.deploy.outputs.finished_at }} --status ${{ steps.deploy.outcome }} --commit_sha $GITHUB_SHA --project_name $(basename $GITHUB_REPOSITORY) --branch_name $(echo $GITHUB_REF | sed s#refs/heads/## ) --repository_url ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}  --environment "prod" --hosting_environment "dalmatian" --deployment_id $GITHUB_RUN_ID
+          bundle exec ruby deployment-frequency.rb --started_at ${{ steps.before-action.outputs.start-time }} --finished_at ${{ steps.after-action.outputs.finish-time }} --status ${{ steps.deploy.outcome }} --commit_sha $GITHUB_SHA --project_name $(basename $GITHUB_REPOSITORY) --branch_name $(echo $GITHUB_REF | sed s#refs/heads/## ) --repository_url ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}  --environment "prod" --hosting_environment "dalmatian" --deployment_id $GITHUB_RUN_ID

--- a/after-action-dockerfile
+++ b/after-action-dockerfile
@@ -1,0 +1,7 @@
+FROM alpine
+
+RUN apk add bash
+
+COPY scripts /scripts
+
+ENTRYPOINT ["/scripts/after-action.sh"]

--- a/after-action/action.yml
+++ b/after-action/action.yml
@@ -1,0 +1,9 @@
+# action.yml
+name: 'After action'
+description: 'Collects finish time'
+outputs:
+  finish-time:
+    description: 'the time the action run ends'
+runs:
+  using: 'docker'
+  image: '../after-action-dockerfile'

--- a/scripts/after-action.sh
+++ b/scripts/after-action.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -l
+
+time=$(date)
+echo "::set-output name=finish-time::$time"


### PR DESCRIPTION
This is a simple after aciton to run after a deployment. For now all it does is records the `finish-time` of the step and exposes it to Github actions for use later.

WIth this and the before-aciton, we have a nice reuseable way to add steps around a deployments steps to record metrics.