### PR TITLE
Deploy information is fetched automatically

### DIFF
--- a/.github/workflows/store-latest-release-metadata.yaml
+++ b/.github/workflows/store-latest-release-metadata.yaml
@@ -1,7 +1,7 @@
 name: Store latest release metadata
 on:
-# schedule:
-#   - cron: '*/5 * * * *'
+  schedule:
+    - cron: '*/20 7-22 * * 1-5'
   workflow_dispatch:
 env:
   INFLUX_API_TOKEN: ${{ secrets.INFLUX_API_TOKEN }}


### PR DESCRIPTION
> Every 20 minutes from 7am through 10pm on Monday through Friday

This task has been run manually and we trust it well enough to have it
run automatically on a schedule.

The schedule we think appropriate is every 20 minutes, as we aren't
familiar with any deployments happening quicker than this. Every week
day because we shouldn't be deploying on weekends. It starts at 7am and
stops at 10pm to account for different working patterns, different time
zones or doing emergency hotfixes in the evening.

OOH deploys are theoretically possible however we haven't tried to cater
for this in an effort to keep the amount of resources used to a minimum.
We could leave this on 24 hours a day but the chances of a 2am deploy
are so rare, the dataset shouldn't be affected.

We are aware that GitHub Actions will stop working if the project goes
into an inactive state for more than 60 days[1]. We _hope_ this won't
happen given the dependency updates that we tend to keep updated.

There is still a risk that this doesn't happen and the polling for new
data stops. We believe an email is sent to inform someone at dxw that
this job has stopped but this also has a risk of being missed.

[1] https://github.community/t/no-notification-workflow-disabled-after-60-days/182169/6

Co-authored-by: Cristina <cristina@dxw.com>