### PR TITLE
Update RODA deployment branch name

### DIFF
--- a/scripts/analyse_latest_release.rb
+++ b/scripts/analyse_latest_release.rb
@@ -20,7 +20,7 @@ MONITORED_SITES = [
     env: "production",
     endpoint: "https://www.report-official-development-assistance.service.gov.uk/health_check",
     repository: "UKGovernmentBEIS/beis-report-official-development-assistance",
-    branch_name: "master"
+    branch_name: "main"
   },
   {
     project: "roda",

--- a/scripts/analyse_releases_from_historical_github_actions.rb
+++ b/scripts/analyse_releases_from_historical_github_actions.rb
@@ -21,7 +21,7 @@ MONITORED_SITES = [
     env: "production",
     endpoint: "https://www.report-official-development-assistance.service.gov.uk/health_check",
     repository: "UKGovernmentBEIS/beis-report-official-development-assistance",
-    branch_name: "master"
+    branch_name: "main"
   },
   {
     project: "roda",


### PR DESCRIPTION
We've switched from `master` to `main` on RODA now, so these scripts need to point at the correct branch to pick up release data.